### PR TITLE
Speed up trackread.a a little

### DIFF
--- a/amiga/native/trackread.a
+++ b/amiga/native/trackread.a
@@ -9,7 +9,7 @@ _grab_track:
    LEA.L       $DFF01A,A1  ; A1 = DSKBYTR
    LEA.L       $BFD400,A2  ; A2 = CIAA.CIATALO
    LEA.L       $BFDD00,A3  ; A3 = CIAA.CIAICR
-   MOVE.L      #3,D5       ; D5 = amount to shift DSKIDX
+   MOVE.L      #$10,D5     ; D5 = DSKIDX bit
    MOVE.L      #$80,D6     ; D6 = mask for DSKIDX destination bit
 
 byte_detect:
@@ -20,9 +20,9 @@ byte_detect:
    MOVE.B      (A2),D3     ; D3 = THIS_CIATALO
    SUB.B       D3,D2       ; D2 = PREV_CIATALO - THIS_CIATALO
 
-   MOVE.B      (A3),D4
-   LSL.B       D5,D4
-   AND.B       D6,D4
+   BTST.B      D5,(A3)     ; Check bit 4 (DSKIDX)
+   SNE.B       D4          ; If it was set, set all bits of D4
+   AND.B       D7, D4      ; Clear all but bit 7
    OR.B        D4,D2       ; D2 |= DSKIDX << 7
 
    MOVE.B      D2,(A0)+       ; D2 <<= 8; D2 |= (UBYTE)DSKBYT

--- a/amiga/native/trackread.a
+++ b/amiga/native/trackread.a
@@ -5,10 +5,12 @@
 
 ; void grab_track(register __a0 char *dat, register __d0 int count);
 _grab_track:
-   MOVEM.L     D0-D4/A0-A3,-(SP)
+   MOVEM.L     D0-D6/A0-A3,-(SP)
    LEA.L       $DFF01A,A1  ; A1 = DSKBYTR
    LEA.L       $BFD400,A2  ; A2 = CIAA.CIATALO
    LEA.L       $BFDD00,A3  ; A3 = CIAA.CIAICR
+   MOVE.L      #3,D5       ; D5 = amount to shift DSKIDX
+   MOVE.L      #$80,D6     ; D6 = mask for DSKIDX destination bit
 
 byte_detect:
    MOVE.W      (A1),D1     ; D1 = DSKBYT
@@ -19,18 +21,17 @@ byte_detect:
    SUB.B       D3,D2       ; D2 = PREV_CIATALO - THIS_CIATALO
 
    MOVE.B      (A3),D4
-   LSL.B       #3,D4
-   AND.B       #$80,D4
+   LSL.B       D5,D4
+   AND.B       D6,D4
    OR.B        D4,D2       ; D2 |= DSKIDX << 7
 
-   LSL.W       #8,D2
-   MOVE.B      D1,D2       ; D2 <<= 8; D2 |= (UBYTE)DSKBYT
-   MOVE.W      D2,(A0)+
+   MOVE.B      D2,(A0)+       ; D2 <<= 8; D2 |= (UBYTE)DSKBYT
+   MOVE.B      D1,(A0)+
 
    SUBQ.L      #2,D0
    BNE.B       byte_detect
 
-   MOVEM.L     (SP)+,D0-D4/A0-A3
+   MOVEM.L     (SP)+,D0-D6/A0-A3
    RTS
 
    END


### PR DESCRIPTION
My amiga 1000 was taking a bit over 16us to run this loop.  That's not fast enough and it was dropping bytes.  Now, it takes about 15us, which I think will be enough.